### PR TITLE
admin panel set up

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -126,6 +126,7 @@ function UserManagementSection() {
             type="text" 
             placeholder="Search users by name or email..." 
             className={styles.searchInput}
+            aria-label="Search users by name or email"
           />
         </div>
 

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,8 +1,221 @@
+import { useState } from 'react';
+import styles from '../styles/AdminDashboard.module.css';
+
 export default function AdminDashboard() {
+  const [activeTab, setActiveTab] = useState('analytics');
+
   return (
-    <div>
-      <h1>Admin Panel</h1>
-      <p>Manage ALL courses and users.</p>
+    <div className={styles.adminContainer}>
+      <header className={styles.header}>
+        <h1>Admin Panel</h1>
+        <p>Manage platform settings, users, and analytics</p>
+      </header>
+
+      <nav className={styles.tabs}>
+        <button 
+          className={`${styles.tab} ${activeTab === 'analytics' ? styles.active : ''}`}
+          onClick={() => setActiveTab('analytics')}
+        >
+          📊 Analytics & Reporting
+        </button>
+        <button 
+          className={`${styles.tab} ${activeTab === 'users' ? styles.active : ''}`}
+          onClick={() => setActiveTab('users')}
+        >
+          👥 User Management
+        </button>
+        <button 
+          className={`${styles.tab} ${activeTab === 'config' ? styles.active : ''}`}
+          onClick={() => setActiveTab('config')}
+        >
+          ⚙️ Configuration
+        </button>
+      </nav>
+
+      <main className={styles.content}>
+        {activeTab === 'analytics' && <AnalyticsSection />}
+        {activeTab === 'users' && <UserManagementSection />}
+        {activeTab === 'config' && <ConfigurationSection />}
+      </main>
+    </div>
+  );
+}
+
+function AnalyticsSection() {
+  return (
+    <div className={styles.section}>
+      <h2>Analytics & Reporting</h2>
+      <p className={styles.subtitle}>Overview of platform usage and content</p>
+
+      <div className={styles.statsGrid}>
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>👤</div>
+          <div className={styles.statInfo}>
+            <h3>Total Users</h3>
+            <p className={styles.statNumber}>-</p>
+            <span className={styles.statLabel}>Active users on platform</span>
+          </div>
+        </div>
+
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>📝</div>
+          <div className={styles.statInfo}>
+            <h3>Text Content</h3>
+            <p className={styles.statNumber}>-</p>
+            <span className={styles.statLabel}>Total text lessons</span>
+          </div>
+        </div>
+
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>🎨</div>
+          <div className={styles.statInfo}>
+            <h3>Visual Content</h3>
+            <p className={styles.statNumber}>-</p>
+            <span className={styles.statLabel}>Total visual lessons</span>
+          </div>
+        </div>
+
+        <div className={styles.statCard}>
+          <div className={styles.statIcon}>🎧</div>
+          <div className={styles.statInfo}>
+            <h3>Audio Content</h3>
+            <p className={styles.statNumber}>-</p>
+            <span className={styles.statLabel}>Total audio lessons</span>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.tableSection}>
+        <h3>User Activity Summary</h3>
+        <p className={styles.tableSubtitle}>Who's using it and what they've created</p>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Content Created</th>
+              <th>Last Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className={styles.emptyRow}>
+              <td colSpan="5">No user activity data yet</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function UserManagementSection() {
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h2>User Management</h2>
+          <p className={styles.subtitle}>Create, edit, and manage user accounts</p>
+        </div>
+        <button className={styles.primaryButton}>+ Create New User</button>
+      </div>
+
+      <div className={styles.tableSection}>
+        <div className={styles.searchBar}>
+          <input 
+            type="text" 
+            placeholder="Search users by name or email..." 
+            className={styles.searchInput}
+          />
+        </div>
+
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th>Created</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className={styles.emptyRow}>
+              <td colSpan="6">No users to display</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ConfigurationSection() {
+  return (
+    <div className={styles.section}>
+      <h2>Configuration Settings</h2>
+      <p className={styles.subtitle}>Manage platform-wide settings and content limits</p>
+
+      <div className={styles.configCard}>
+        <h3>📝 Text Content Limits</h3>
+        <p className={styles.configDescription}>Set character and word count limits for text-based lessons</p>
+        
+        <div className={styles.configForm}>
+          <div className={styles.formGroup}>
+            <label htmlFor="charLimit">Maximum Character Count</label>
+            <input 
+              type="number" 
+              id="charLimit" 
+              placeholder="e.g., 5000"
+              className={styles.configInput}
+            />
+            <span className={styles.helpText}>Maximum characters allowed per text lesson</span>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="wordLimit">Maximum Word Count</label>
+            <input 
+              type="number" 
+              id="wordLimit" 
+              placeholder="e.g., 1000"
+              className={styles.configInput}
+            />
+            <span className={styles.helpText}>Maximum words allowed per text lesson</span>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="minLength">Minimum Character Count</label>
+            <input 
+              type="number" 
+              id="minLength" 
+              placeholder="e.g., 50"
+              className={styles.configInput}
+            />
+            <span className={styles.helpText}>Minimum characters required for a valid lesson</span>
+          </div>
+        </div>
+
+        <button className={styles.saveButton}>Save Configuration</button>
+      </div>
+
+      <div className={styles.configCard}>
+        <h3>📊 Current Settings Overview</h3>
+        <div className={styles.settingsList}>
+          <div className={styles.settingItem}>
+            <span className={styles.settingLabel}>Max Characters:</span>
+            <span className={styles.settingValue}>Not configured</span>
+          </div>
+          <div className={styles.settingItem}>
+            <span className={styles.settingLabel}>Max Words:</span>
+            <span className={styles.settingValue}>Not configured</span>
+          </div>
+          <div className={styles.settingItem}>
+            <span className={styles.settingLabel}>Min Characters:</span>
+            <span className={styles.settingValue}>Not configured</span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/AdminDashboard.css
+++ b/frontend/src/styles/AdminDashboard.css
@@ -1,0 +1,261 @@
+.admin-dashboard {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.admin-dashboard h1 {
+  margin-bottom: 2rem;
+  color: #333;
+}
+
+.admin-tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.admin-tabs button {
+  padding: 0.75rem 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: #666;
+  border-bottom: 3px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.admin-tabs button:hover {
+  color: #333;
+}
+
+.admin-tabs button.active {
+  color: #007bff;
+  border-bottom-color: #007bff;
+}
+
+.admin-section {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.admin-section h2 {
+  margin-bottom: 1.5rem;
+  color: #333;
+}
+
+.admin-section h3 {
+  margin: 1.5rem 0 1rem;
+  color: #555;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 1.5rem;
+  border-radius: 8px;
+  color: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.stat-card h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+  color: white;
+}
+
+.stat-number {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin: 0;
+}
+
+/* Table Styles */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.admin-table th {
+  background-color: #f8f9fa;
+  font-weight: 600;
+  color: #333;
+}
+
+.admin-table tbody tr:hover {
+  background-color: #f8f9fa;
+}
+
+.status-badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.status-badge.active {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.status-badge.inactive {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+/* Form Styles */
+.create-user-form {
+  background-color: #f8f9fa;
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+}
+
+.create-user-form h3 {
+  margin-top: 0;
+}
+
+.create-user-form form {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.create-user-form input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.create-user-form button {
+  padding: 0.75rem 1.5rem;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s ease;
+}
+
+.create-user-form button:hover {
+  background-color: #0056b3;
+}
+
+.config-form {
+  max-width: 600px;
+}
+
+.config-description {
+  color: #666;
+  margin-bottom: 2rem;
+  line-height: 1.6;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 0.5rem;
+  color: #666;
+  font-size: 0.875rem;
+}
+
+/* Buttons */
+.btn-primary {
+  padding: 0.75rem 2rem;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s ease;
+}
+
+.btn-primary:hover {
+  background-color: #0056b3;
+}
+
+.btn-danger {
+  padding: 0.5rem 1rem;
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background-color 0.3s ease;
+}
+
+.btn-danger:hover {
+  background-color: #c82333;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .admin-dashboard {
+    padding: 1rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-table {
+    font-size: 0.875rem;
+  }
+
+  .admin-table th,
+  .admin-table td {
+    padding: 0.5rem;
+  }
+
+  .create-user-form form {
+    flex-direction: column;
+  }
+
+  .create-user-form input {
+    min-width: 100%;
+  }
+}

--- a/frontend/src/styles/AdminDashboard.module.css
+++ b/frontend/src/styles/AdminDashboard.module.css
@@ -1,0 +1,386 @@
+@import './variables.css';
+
+.adminContainer {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: 'DM Sans', sans-serif;
+}
+
+.header {
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  font-family: 'Lora', serif;
+  font-size: 2.5rem;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+}
+
+.header p {
+  color: var(--ink-soft);
+  font-size: 1.125rem;
+}
+
+/* Tabs Navigation */
+.tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  border-bottom: 2px solid var(--sky-light);
+  flex-wrap: wrap;
+}
+
+.tab {
+  background: none;
+  border: none;
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+  cursor: pointer;
+  border-bottom: 3px solid transparent;
+  transition: all 0.3s ease;
+  font-family: 'DM Sans', sans-serif;
+}
+
+.tab:hover {
+  color: var(--accent);
+  background-color: var(--accent-light);
+}
+
+.tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+/* Content Sections */
+.content {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.section {
+  background: var(--cloud);
+  border-radius: var(--radius);
+  padding: 2rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.section h2 {
+  font-family: 'Lora', serif;
+  font-size: 2rem;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--ink-soft);
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+/* Analytics Stats Grid */
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.statCard {
+  background: linear-gradient(135deg, var(--sky-light) 0%, var(--cloud) 100%);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  border: 1px solid var(--sky-mid);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.statCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.statIcon {
+  font-size: 2.5rem;
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cloud);
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.statInfo h3 {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ink-soft);
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.statNumber {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin: 0.25rem 0;
+}
+
+.statLabel {
+  font-size: 0.875rem;
+  color: var(--ink-muted);
+}
+
+/* Tables */
+.tableSection {
+  margin-top: 2rem;
+}
+
+.tableSection h3 {
+  font-size: 1.5rem;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+}
+
+.tableSubtitle {
+  color: var(--ink-soft);
+  font-size: 0.875rem;
+  margin-bottom: 1.5rem;
+}
+
+.searchBar {
+  margin-bottom: 1.5rem;
+}
+
+.searchInput {
+  width: 100%;
+  max-width: 500px;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--sky-mid);
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: 'DM Sans', sans-serif;
+  transition: border-color 0.2s ease;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--cloud);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.table thead {
+  background: var(--sky-light);
+}
+
+.table th {
+  text-align: left;
+  padding: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.table td {
+  padding: 1rem;
+  border-top: 1px solid var(--sky-light);
+  color: var(--ink-soft);
+}
+
+.table tbody tr:hover {
+  background-color: var(--sky-light);
+}
+
+.emptyRow td {
+  text-align: center;
+  padding: 3rem;
+  color: var(--ink-muted);
+  font-style: italic;
+}
+
+/* Configuration Cards */
+.configCard {
+  background: var(--sky-light);
+  border-radius: var(--radius);
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid var(--sky-mid);
+}
+
+.configCard h3 {
+  font-size: 1.5rem;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+}
+
+.configDescription {
+  color: var(--ink-soft);
+  margin-bottom: 2rem;
+}
+
+.configForm {
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.formGroup label {
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.configInput {
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--sky-mid);
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: 'DM Sans', sans-serif;
+  background: var(--cloud);
+  transition: border-color 0.2s ease;
+}
+
+.configInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.helpText {
+  font-size: 0.875rem;
+  color: var(--ink-muted);
+  font-style: italic;
+}
+
+.settingsList {
+  display: grid;
+  gap: 1rem;
+}
+
+.settingItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: var(--cloud);
+  border-radius: 8px;
+}
+
+.settingLabel {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.settingValue {
+  color: var(--ink-soft);
+  font-family: monospace;
+}
+
+/* Buttons */
+.primaryButton {
+  background: var(--accent);
+  color: var(--cloud);
+  border: none;
+  padding: 0.875rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: 'DM Sans', sans-serif;
+}
+
+.primaryButton:hover {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(59, 111, 212, 0.3);
+}
+
+.saveButton {
+  background: var(--accent);
+  color: var(--cloud);
+  border: none;
+  padding: 0.875rem 2rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: 'DM Sans', sans-serif;
+}
+
+.saveButton:hover {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(59, 111, 212, 0.3);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .adminContainer {
+    padding: 1rem;
+  }
+
+  .header h1 {
+    font-size: 2rem;
+  }
+
+  .statsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .table {
+    font-size: 0.875rem;
+  }
+
+  .table th,
+  .table td {
+    padding: 0.75rem 0.5rem;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tab {
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+  }
+}


### PR DESCRIPTION
fixes issue #84 

On the admin panel, there are now tabs for:
1. Analytics and reporting -> reports numbers of users for types of content, and lists users
2. User management -> shows users and their roles, option for admin to create new user
3. Configuration -> set text content limits as an admin

It is currently just the visual template

### Testing

1. `git checkout feature/issue-84-admin-draft`
2. Review and see if that's correctly what is visually needed for the admin panel